### PR TITLE
Stop assuming everyone wants context in a nested json field.  Expand …

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ def run_add_context():
     "tag": "JOURNAL_MSG_JSON",
     "format": "0.2.0",
     "objective": "add_context",
-    "context": {"app_version": "0.1.0"},
     "arguments": {"a": 2, "b": [1, 2]},
-    "results": [6, [2, 4]]
+    "results": [6, [2, 4]],
+    "app_version": "0.1.0"
 }
 ```
 
@@ -328,7 +328,7 @@ Log Message:
         "tag": "JOURNAL_MSG_JSON",
         "format": "0.2.0",
         "objective": "log_format",
-        "context": {"app_version": "0.1.0"},
+        app_version": "0.1.0",
         "arguments": {"a": 2, "b": [1, 2]},
         "results": [6, [2, 4]],
     }

--- a/src/callable_journal/formatter.py
+++ b/src/callable_journal/formatter.py
@@ -103,9 +103,13 @@ class JournalFormatter(Formatter):
 
         content = self.encoder.encode(record.journal_content)
 
-        # Remove the context if none was specified.
-        if not content["context"]:
-            del content["context"]
+        # Unwrap the context into top level elements.  If context should
+        # be contained in a single conext element then wrap the context
+        # in {"context": {...}} when it is passed to journal_init.
+        context = content["context"] or dict()
+        del content["context"]
+        for k, v in context.items():
+            content[k] = v
 
         # Remove the exception if there is no exception.
         if not content["exception"]:

--- a/test/docs_example_test.py
+++ b/test/docs_example_test.py
@@ -187,7 +187,7 @@ def run_add_context():
         "tag": "JOURNAL_MSG_JSON",
         "format": "0.2.0",
         "objective": "add_context",
-        "context": {"app_version": "0.1.0"},
+        "app_version": "0.1.0",
         "arguments": {"a": 2, "b": [1, 2]},
         "results": [6, [2, 4]],
     }

--- a/test/journal_test.py
+++ b/test/journal_test.py
@@ -7,8 +7,10 @@ from ndl_tools import Differ, PathNormalizer, EndsWithSelector
 from callable_journal.journal import journal, journal_init
 
 context = dict(
-    service_ctx=dict(name="Test Service", version="0.1.0"),
-    implementation_ctx=dict(name="Simple Model", version="0.1.0"),
+    context=dict(
+        service_ctx=dict(name="Test Service", version="0.1.0"),
+        implementation_ctx=dict(name="Simple Model", version="0.1.0"),
+    )
 )
 JOURNAL_CFG_FPATH = Path(__file__).parent / "journal-cfg.yml"
 
@@ -72,7 +74,7 @@ def test_exception(capsys):
             "type": "ZeroDivisionError",
             "msg": "division by zero",
             "file": "/home/some_user/projects/callable-journal/test/journal_test.py",
-            "line": "50",
+            "line": "52",
         },
     }
 


### PR DESCRIPTION
…the top level of the context into the record before formatting.

If a top level context field is desired then pass dict(context={...}) as the context parameter.