### PR TITLE
Unnest Context, Show @journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ def run_add_context():
     "tag": "JOURNAL_MSG_JSON",
     "format": "0.2.0",
     "objective": "add_context",
-    "context": {"app_version": "0.1.0"},
     "arguments": {"a": 2, "b": [1, 2]},
-    "results": [6, [2, 4]]
+    "results": [6, [2, 4]],
+    "app_version": "0.1.0"
 }
 ```
 
@@ -328,7 +328,7 @@ Log Message:
         "tag": "JOURNAL_MSG_JSON",
         "format": "0.2.0",
         "objective": "log_format",
-        "context": {"app_version": "0.1.0"},
+        app_version": "0.1.0",
         "arguments": {"a": 2, "b": [1, 2]},
         "results": [6, [2, 4]],
     }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Wouldn't it be nice if you could just do this!
 from typing import List, Tuple
 from callable_journal import journal
 
-@journal()
+@journal
 def basic(a: int, b: List[int]) -> Tuple[int, List[int]]:
     multiplied = [a * b_item for b_item in b]
     return sum(multiplied), multiplied
@@ -178,7 +178,7 @@ from pathlib import Path
 from typing import List, Tuple
 from callable_journal import journal, journal_init
 
-@journal()
+@journal
 def add_context(a: int, b: List[int]) -> Tuple[int, List[int]]:
     multiplied = [a * b_item for b_item in b]
     return sum(multiplied), multiplied

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,12 +21,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.1.0"
+version = "20.2.0"
 
 [package.extras]
 dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
 category = "dev"
@@ -197,7 +198,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "6.0.1"
+version = "6.0.2"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -317,8 +318,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.1.0-py2.py3-none-any.whl", hash = "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"},
-    {file = "attrs-20.1.0.tar.gz", hash = "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a"},
+    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
+    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
 ]
 black = [
     {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
@@ -428,8 +429,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.0.1-py3-none-any.whl", hash = "sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad"},
-    {file = "pytest-6.0.1.tar.gz", hash = "sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4"},
+    {file = "pytest-6.0.2-py3-none-any.whl", hash = "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40"},
+    {file = "pytest-6.0.2.tar.gz", hash = "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "callable-journal"
-version = "0.0.8"
+version = "0.0.9"
 description = "Log message generator for a callable's argument and return values."
 authors = ["Nate Atkins <atkinsnw@gmail.com>"]
 license = "MIT"

--- a/src/callable_journal/formatter.py
+++ b/src/callable_journal/formatter.py
@@ -103,9 +103,13 @@ class JournalFormatter(Formatter):
 
         content = self.encoder.encode(record.journal_content)
 
-        # Remove the context if none was specified.
-        if not content["context"]:
-            del content["context"]
+        # Unwrap the context into top level elements.  If context should
+        # be contained in a single conext element then wrap the context
+        # in {"context": {...}} when it is passed to journal_init.
+        context = content["context"] or dict()
+        del content["context"]
+        for k, v in context.items():
+            content[k] = v
 
         # Remove the exception if there is no exception.
         if not content["exception"]:

--- a/src/callable_journal/journal.py
+++ b/src/callable_journal/journal.py
@@ -4,7 +4,7 @@ Public interface to the journal decorator.
 import functools
 import logging.config
 from pathlib import Path
-from typing import Any, List, Optional, Mapping, Union
+from typing import Any, List, Optional, Mapping, Union, Callable
 
 import yaml
 from pydantic.main import BaseModel
@@ -53,7 +53,7 @@ def journal_init(logging_cfg_fpath: Path, context: Optional[ANY_JSON_SERIALIZABL
 
 @curry
 def journal(
-    callable,
+    callable: Callable,
     *,
     objective: Optional[str] = None,
     result_names: Optional[Union[str, List[str]]] = None,

--- a/test/docs_example_test.py
+++ b/test/docs_example_test.py
@@ -187,7 +187,7 @@ def run_add_context():
         "tag": "JOURNAL_MSG_JSON",
         "format": "0.2.0",
         "objective": "add_context",
-        "context": {"app_version": "0.1.0"},
+        "app_version": "0.1.0",
         "arguments": {"a": 2, "b": [1, 2]},
         "results": [6, [2, 4]],
     }

--- a/test/docs_example_test.py
+++ b/test/docs_example_test.py
@@ -39,7 +39,7 @@ def motivation_with_logging(a: int, b: List[int]) -> Tuple[int, List[int]]:
     return sum(multiplied), multiplied
 
 
-@journal()
+@journal
 def basic(a: int, b: List[int]) -> Tuple[int, List[int]]:
     multiplied = [a * b_item for b_item in b]
     return sum(multiplied), multiplied
@@ -171,7 +171,7 @@ def test_drop_args(capsys):
     # print(captured[0])
 
 
-@journal()
+@journal
 def add_context(a: int, b: List[int]) -> Tuple[int, List[int]]:
     multiplied = [a * b_item for b_item in b]
     return sum(multiplied), multiplied
@@ -233,7 +233,7 @@ def test_exception(capsys):
     # print(captured[0])
 
 
-@journal()
+@journal
 def log_format(a: int, b: List[int]) -> Tuple[int, List[int]]:
     multiplied = [a * b_item for b_item in b]
     return sum(multiplied), multiplied

--- a/test/journal_test.py
+++ b/test/journal_test.py
@@ -7,8 +7,10 @@ from ndl_tools import Differ, PathNormalizer, EndsWithSelector
 from callable_journal.journal import journal, journal_init
 
 context = dict(
-    service_ctx=dict(name="Test Service", version="0.1.0"),
-    implementation_ctx=dict(name="Simple Model", version="0.1.0"),
+    context=dict(
+        service_ctx=dict(name="Test Service", version="0.1.0"),
+        implementation_ctx=dict(name="Simple Model", version="0.1.0"),
+    )
 )
 JOURNAL_CFG_FPATH = Path(__file__).parent / "journal-cfg.yml"
 
@@ -72,7 +74,7 @@ def test_exception(capsys):
             "type": "ZeroDivisionError",
             "msg": "division by zero",
             "file": "/home/some_user/projects/callable-journal/test/journal_test.py",
-            "line": "50",
+            "line": "52",
         },
     }
 


### PR DESCRIPTION
1. Unnest the context so that it isn't automatically wrapped assigned to context.   
2. Clean up documentation to show that when there are no arguments the journal decorator can just be @journal instead of @journal()